### PR TITLE
アイテム編集画面に遷移する実装を追加しました

### DIFF
--- a/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
+++ b/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
@@ -80,16 +80,8 @@
                         <viewLayoutGuide key="safeArea" id="Nhx-gw-fqI"/>
                     </view>
                     <navigationItem key="navigationItem" id="4Pk-Jc-M8J">
-                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ">
-                            <connections>
-                                <action selector="tapCancel:" destination="f9M-Mn-WVJ" id="yeU-3T-rdh"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" style="plain" systemItem="save" id="GAL-SW-4Mb">
-                            <connections>
-                                <action selector="tapSave:" destination="f9M-Mn-WVJ" id="Kgc-xM-HQW"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ"/>
+                        <barButtonItem key="rightBarButtonItem" enabled="NO" style="plain" systemItem="save" id="GAL-SW-4Mb"/>
                     </navigationItem>
                     <connections>
                         <outlet property="nameTextField" destination="oAG-ld-2Ds" id="go4-ch-rTG"/>

--- a/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
+++ b/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
@@ -94,20 +94,13 @@
                         <viewLayoutGuide key="safeArea" id="Nhx-gw-fqI"/>
                     </view>
                     <navigationItem key="navigationItem" id="4Pk-Jc-M8J">
-                        <barButtonItem key="leftBarButtonItem" tag="1" style="plain" systemItem="cancel" id="21c-Dq-ZhJ">
-                            <connections>
-                                <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="Vcc-vh-qC0"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="save" id="GAL-SW-4Mb">
-                            <connections>
-                                <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="PRe-mY-UXl"/>
-                            </connections>
-                        </barButtonItem>
+                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ"/>
+                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="save" id="GAL-SW-4Mb"/>
                     </navigationItem>
                     <connections>
                         <outlet property="nameTextField" destination="oAG-ld-2Ds" id="go4-ch-rTG"/>
                         <outlet property="saveButton" destination="GAL-SW-4Mb" id="4PH-v4-LxG"/>
+                        <segue destination="DIn-7y-ruS" kind="unwind" identifier="Exit" unwindAction="exitDoneWithSegue:" id="0jK-Rm-cUW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rGR-oZ-0J5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
+++ b/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
@@ -80,8 +80,16 @@
                         <viewLayoutGuide key="safeArea" id="Nhx-gw-fqI"/>
                     </view>
                     <navigationItem key="navigationItem" id="4Pk-Jc-M8J">
-                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ"/>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" style="plain" systemItem="save" id="GAL-SW-4Mb"/>
+                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ">
+                            <connections>
+                                <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="Vcc-vh-qC0"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" enabled="NO" style="plain" systemItem="save" id="GAL-SW-4Mb">
+                            <connections>
+                                <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="PRe-mY-UXl"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="nameTextField" destination="oAG-ld-2Ds" id="go4-ch-rTG"/>
@@ -89,6 +97,7 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rGR-oZ-0J5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="DIn-7y-ruS" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="1047.8260869565217" y="862.5"/>
         </scene>

--- a/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
+++ b/GoodFirstIssue-ToDoApp/Base.lproj/Main.storyboard
@@ -14,13 +14,27 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qO1-y7-qB6">
+                                <rect key="frame" x="129" y="427.5" width="156" height="41"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <state key="normal" title="To Edit VC Test"/>
+                                <connections>
+                                    <action selector="toEditVCTestTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="0kf-6L-DKB"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="qO1-y7-qB6" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="e1B-yH-7Hv"/>
+                            <constraint firstItem="qO1-y7-qB6" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="fsJ-oX-XB8"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" title="チェックリスト" id="Roy-Ci-y24">
                         <barButtonItem key="rightBarButtonItem" title="Item" image="plus" catalog="system" id="b1N-JF-cck">
                             <connections>
-                                <segue destination="Xpa-hb-3QJ" kind="presentation" id="0l6-cl-DUx"/>
+                                <segue destination="Xpa-hb-3QJ" kind="presentation" identifier="ToItemEditVC" id="0l6-cl-DUx"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -80,12 +94,12 @@
                         <viewLayoutGuide key="safeArea" id="Nhx-gw-fqI"/>
                     </view>
                     <navigationItem key="navigationItem" id="4Pk-Jc-M8J">
-                        <barButtonItem key="leftBarButtonItem" style="plain" systemItem="cancel" id="21c-Dq-ZhJ">
+                        <barButtonItem key="leftBarButtonItem" tag="1" style="plain" systemItem="cancel" id="21c-Dq-ZhJ">
                             <connections>
                                 <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="Vcc-vh-qC0"/>
                             </connections>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" style="plain" systemItem="save" id="GAL-SW-4Mb">
+                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="save" id="GAL-SW-4Mb">
                             <connections>
                                 <segue destination="DIn-7y-ruS" kind="unwind" unwindAction="exitDoneWithSegue:" id="PRe-mY-UXl"/>
                             </connections>

--- a/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
+++ b/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
@@ -8,26 +8,45 @@
 
 import UIKit
 
-class ItemEditViewController: UIViewController {
+class ItemEditViewController: UIViewController, ItemEditViewProtocol {
+    
+    // MARK: ItemEditViewProtocol
 
+    var itemId: Int?
+    var initialName: String?
+    var itemName: String {
+        nameTextField.text ?? ""
+    }
+    
+    // MARK: Implementation
+    
     @IBOutlet weak private var saveButton: UIBarButtonItem!
     @IBOutlet weak private var nameTextField: UITextField!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "項目追加"
+        
+        nameTextField.text = initialName
         nameTextField.delegate = self
+        
+        saveButton.isEnabled = nameTextField.text != ""
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(_:)))
         view.addGestureRecognizer(tapGesture)
     }
-
-    @objc private func tapped(_ sender: UITapGestureRecognizer) {
-        if sender.state == .ended {
-            nameTextField.endEditing(true)
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        
+        // cancelボタンが押された場合は、遷移の前にtextを空にする
+        if let barButtonItem = sender as? UIBarButtonItem, BarButtonType(rawValue: barButtonItem.tag) == .cancel {
+            nameTextField.text = ""
         }
     }
 }
+
+// MARK: UITextFieldDelegate
 
 extension ItemEditViewController: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
@@ -36,5 +55,21 @@ extension ItemEditViewController: UITextFieldDelegate {
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         nameTextField.endEditing(true)
+    }
+}
+
+// MARK: private
+
+private extension ItemEditViewController {
+    // Storyboardで設定したtagの値に対応
+    enum BarButtonType: Int {
+        case save = 0
+        case cancel = 1
+    }
+    
+    @objc func tapped(_ sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
+            nameTextField.endEditing(true)
+        }
     }
 }

--- a/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
+++ b/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
@@ -10,37 +10,26 @@ import UIKit
 
 class ItemEditViewController: UIViewController {
 
-    @IBOutlet weak var saveButton: UIBarButtonItem!
-    @IBOutlet weak var nameTextField: UITextField!
+    @IBOutlet weak private var saveButton: UIBarButtonItem!
+    @IBOutlet weak private var nameTextField: UITextField!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "項目追加"
         nameTextField.delegate = self
         
-        let tapGesture = UITapGestureRecognizer(target: self,action: #selector(tapped(_:)))
-        
-        self.view.addGestureRecognizer(tapGesture)
-        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(_:)))
+        view.addGestureRecognizer(tapGesture)
     }
 
-    @objc func tapped(_ sender: UITapGestureRecognizer){
+    @objc private func tapped(_ sender: UITapGestureRecognizer) {
         if sender.state == .ended {
             nameTextField.endEditing(true)
         }
     }
-
-    @IBAction func tapCancel(_ sender: Any) {
-        dismiss(animated: false)
-    }
-    
-    @IBAction func tapSave(_ sender: Any) {
-        dismiss(animated: false)
-    }
 }
 
 extension ItemEditViewController: UITextFieldDelegate {
-
     func textFieldDidChangeSelection(_ textField: UITextField) {
         saveButton.isEnabled = nameTextField.text != ""
     }

--- a/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
+++ b/GoodFirstIssue-ToDoApp/Screens/ItemEdit/ItemEditViewController.swift
@@ -34,15 +34,8 @@ class ItemEditViewController: UIViewController, ItemEditViewProtocol {
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped(_:)))
         view.addGestureRecognizer(tapGesture)
-    }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        super.prepare(for: segue, sender: sender)
         
-        // cancelボタンが押された場合は、遷移の前にtextを空にする
-        if let barButtonItem = sender as? UIBarButtonItem, BarButtonType(rawValue: barButtonItem.tag) == .cancel {
-            nameTextField.text = ""
-        }
+        setupBarButtonActions()
     }
 }
 
@@ -61,15 +54,29 @@ extension ItemEditViewController: UITextFieldDelegate {
 // MARK: private
 
 private extension ItemEditViewController {
-    // Storyboardで設定したtagの値に対応
-    enum BarButtonType: Int {
-        case save = 0
-        case cancel = 1
+    enum Segue {
+        static let Exit = "Exit"
     }
     
     @objc func tapped(_ sender: UITapGestureRecognizer) {
         if sender.state == .ended {
             nameTextField.endEditing(true)
         }
+    }
+    
+    func setupBarButtonActions() {
+        navigationItem.leftBarButtonItem?.target = self
+        navigationItem.leftBarButtonItem?.action = #selector(cancelButtonTapped(_:))
+        navigationItem.rightBarButtonItem?.target = self
+        navigationItem.rightBarButtonItem?.action = #selector(saveButtonTapped(_:))
+    }
+    
+    @objc func saveButtonTapped(_ sender: UIBarButtonItem) {
+        performSegue(withIdentifier: Segue.Exit, sender: nil)
+    }
+    
+    @objc func cancelButtonTapped(_ sender: UIBarButtonItem) {
+        nameTextField.text = ""
+        performSegue(withIdentifier: Segue.Exit, sender: nil)
     }
 }

--- a/GoodFirstIssue-ToDoApp/Screens/ItemList/ItemListViewController.swift
+++ b/GoodFirstIssue-ToDoApp/Screens/ItemList/ItemListViewController.swift
@@ -12,9 +12,8 @@ class ItemListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
     }
-
-
+    
+    @IBAction private func exitDone(segue: UIStoryboardSegue) {}
 }
 

--- a/GoodFirstIssue-ToDoApp/Screens/ItemList/ItemListViewController.swift
+++ b/GoodFirstIssue-ToDoApp/Screens/ItemList/ItemListViewController.swift
@@ -8,12 +8,61 @@
 
 import UIKit
 
+protocol ItemEditViewProtocol {
+    var itemId: Int? { get set }
+    var initialName: String? { get set }
+    var itemName: String { get }
+}
+
 class ItemListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
-    @IBAction private func exitDone(segue: UIStoryboardSegue) {}
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        
+        // senderがItemのときはitemEditViewに初期値を設定する
+        if segue.identifier == Segue.ToItemEditVC, let item = sender as? TempItem {
+            configure(itemEditViewContainer: segue.destination, with: item)
+        }
+    }
+    
+    @IBAction private func exitDone(segue: UIStoryboardSegue) {
+        guard let itemEditView = segue.source as? ItemEditViewProtocol else {
+            return
+        }
+        
+        print("itemEditView's id: \(itemEditView.itemId ?? -1), name: \(itemEditView.itemName).")
+    }
+
+    @IBAction private func toEditVCTestTapped(_ sender: Any) {
+        // TODO: tableViewCellの編集ボタンが呼ばれたら、itemをsenderとしてsegueを実行する
+        let tempItem = TempItem(id: 10, name: "Test initial name")
+        performSegue(withIdentifier: Segue.ToItemEditVC, sender: tempItem)
+    }
 }
 
+private extension ItemListViewController {
+    enum Segue {
+        static let ToItemEditVC = "ToItemEditVC"
+    }
+
+    // itemEidtViewのcontainerがNavigationControllerである前提
+    func configure(itemEditViewContainer: UIViewController, with item: TempItem) {
+        if let container = itemEditViewContainer as? UINavigationController,
+            var itemEditView = container.topViewController as? ItemEditViewProtocol {
+            itemEditView.itemId = item.id
+            itemEditView.initialName = item.name
+        }
+    }
+}
+
+// TODO: Itemの実装ができたら削除する
+private extension ItemListViewController {
+    struct TempItem {
+        let id: Int
+        let name: String
+    }
+}


### PR DESCRIPTION
よろしくお願いしますー

## 変更内容

### アイテム一覧画面でデータを受け取る

- アイテム追加・編集画面のボタンにunwind segueを利用するように変更
- ItemEditViewProtocolを追加
- unwind segueの受け取り先でItemViewProtocolにキャストしてデータを取得

###  アイテム編集画面に遷移する

- 遷移のテスト用ボタンを追加
- 遷移時にItemEditViewProtocolにキャストしてitemId/initialNameをセット

## 悩んだところ

Segueの扱い方がいまいちわかってない感……

## その他

アイテム編集画面に遷移する部分を実装するにあたって、ItemEditViewControllerも少し変更しました。
